### PR TITLE
Add http service port env var

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-ARGS=(--name vertx-fib-demo -p 8080:8080 -p 9093:9093)
+ARGS=(--name vertx-fib-demo -p HTTP_PORT -p 9093:9093)
 
 if podman pod exists container-jfr; then
     ARGS+=(--pod container-jfr)

--- a/run.sh
+++ b/run.sh
@@ -3,11 +3,11 @@
 set -x
 set -e
 
-ARGS=(--name vertx-fib-demo -p $HTTP_PORT -p 9093:9093)
-
 if [ -z "$HTTP_PORT" ]; then
     HTTP_PORT=8080
 fi
+
+ARGS=(--name vertx-fib-demo -p $HTTP_PORT -p 9093:9093)
 
 if podman pod exists container-jfr; then
     ARGS+=(--pod container-jfr)

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-ARGS=(--name vertx-fib-demo -p HTTP_PORT -p 9093:9093)
+ARGS=(--name vertx-fib-demo -p $HTTP_PORT -p 9093:9093)
 
 if podman pod exists container-jfr; then
     ARGS+=(--pod container-jfr)

--- a/run.sh
+++ b/run.sh
@@ -14,5 +14,6 @@ if podman pod exists container-jfr; then
 fi
 
 ARGS+=(--rm -it quay.io/andrewazores/vertx-fib-demo:latest)
+ARGS+=(--env HTTP_PORT="$HTTP_PORT")
 
-podman run --env HTTP_PORT="$HTTP_PORT" "${ARGS[@]}"
+podman run "${ARGS[@]}"

--- a/run.sh
+++ b/run.sh
@@ -5,10 +5,14 @@ set -e
 
 ARGS=(--name vertx-fib-demo -p $HTTP_PORT -p 9093:9093)
 
+if [ -z "$HTTP_PORT" ]; then
+    HTTP_PORT=8080
+fi
+
 if podman pod exists container-jfr; then
     ARGS+=(--pod container-jfr)
 fi
 
 ARGS+=(--rm -it quay.io/andrewazores/vertx-fib-demo:latest)
 
-podman run "${ARGS[@]}"
+podman run --env HTTP_PORT="$HTTP_PORT" "${ARGS[@]}"

--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,7 @@ if [ -z "$HTTP_PORT" ]; then
     HTTP_PORT=8080
 fi
 
-ARGS=(--name vertx-fib-demo -p $HTTP_PORT -p 9093:9093)
+ARGS=(--name vertx-fib-demo -p $HTTP_PORT:$HTTP_PORT -p 9093:9093)
 
 if podman pod exists container-jfr; then
     ARGS+=(--pod container-jfr)

--- a/src/main/extras/app/entrypoint.sh
+++ b/src/main/extras/app/entrypoint.sh
@@ -3,6 +3,10 @@
 set -x
 set -e
 
+if [ -z "$HTTP_PORT" ]; then
+    HTTP_PORT=8080
+fi
+
 if [ -z "$JMX_PORT" ]; then
     JMX_PORT=9093
 fi

--- a/src/main/java/es/andrewazor/demo/App.java
+++ b/src/main/java/es/andrewazor/demo/App.java
@@ -13,11 +13,11 @@ public class App extends AbstractVerticle {
 
     @Override
     public void start() {
+        int port = getHttpPortEnvVar();
+
         getVertx().createHttpServer(
                 new HttpServerOptions()
-                .setPort(
-                    System.getenv("HTTP_PORT")
-                    )
+                .setPort(port)
                 )
             .requestHandler(configureRouter(getVertx()))
             .listen();
@@ -55,6 +55,14 @@ public class App extends AbstractVerticle {
         BigInteger n1 = fib(i.subtract(BigInteger.ONE));
         BigInteger n2 = fib(i.subtract(BigInteger.TWO));
         return n1.add(n2);
+    }
+
+    static int getHttpPortEnvVar() {
+        try {
+            return Integer.parseInt(System.getenv("HTTP_PORT"));
+        } catch(NumberFormatException e) {
+            return 8080;
+        }
     }
 
 }

--- a/src/main/java/es/andrewazor/demo/App.java
+++ b/src/main/java/es/andrewazor/demo/App.java
@@ -15,7 +15,9 @@ public class App extends AbstractVerticle {
     public void start() {
         getVertx().createHttpServer(
                 new HttpServerOptions()
-                .setPort(8080)
+                .setPort(
+                    System.getenv("HTTP_PORT")
+                    )
                 )
             .requestHandler(configureRouter(getVertx()))
             .listen();


### PR DESCRIPTION
 In case another container is already listening on port 8080, this env var allows the HTTP service to listen on a different port.

Related to cryostat issue [#483](https://github.com/cryostatio/cryostat/issues/483), where both vertx-fib-demo and jfr-datasource attempted to bind to port 8080.